### PR TITLE
fix: Ignore response status code

### DIFF
--- a/logic.cs
+++ b/logic.cs
@@ -38,7 +38,7 @@ namespace PagoPA
 
       var req = new HttpRequestMessage(HttpMethod.Get, url);
       HttpResponseMessage response = client.Send(req);
-      response.EnsureSuccessStatusCode();
+      // response.EnsureSuccessStatusCode();
 
       if (certExpiration < DateTime.Now.AddDays(options.ExpirationDeltaInDays))
       {


### PR DESCRIPTION
We can ignore the response status code, we need only to check TLS cert expiration.
Sometimes api response can be 404, 401, 403 so we can remove this check